### PR TITLE
Add static sticker support and WebP→JPEG conversion for Nvidia img2img

### DIFF
--- a/AI/picgeneration.py
+++ b/AI/picgeneration.py
@@ -438,6 +438,8 @@ def get_image_attachment_from_message(message: types.Message):
         return message.photo[-1]
     if message.document and message.document.mime_type and message.document.mime_type.startswith("image/"):
         return message.document
+    if message.sticker and not message.sticker.is_animated and not message.sticker.is_video:
+        return message.sticker
     if message.reply_to_message:
         if message.reply_to_message.photo:
             return message.reply_to_message.photo[-1]
@@ -447,6 +449,12 @@ def get_image_attachment_from_message(message: types.Message):
             and message.reply_to_message.document.mime_type.startswith("image/")
         ):
             return message.reply_to_message.document
+        if (
+            message.reply_to_message.sticker
+            and not message.reply_to_message.sticker.is_animated
+            and not message.reply_to_message.sticker.is_video
+        ):
+            return message.reply_to_message.sticker
     return None
 
 
@@ -583,6 +591,13 @@ async def handle_nvidia_command(message: types.Message):
 
     try:
         img_bytes = await download_telegram_image(bot, photo)
+        try:
+            pil_img = Image.open(BytesIO(img_bytes)).convert("RGB")
+            buf = BytesIO()
+            pil_img.save(buf, format="JPEG", quality=95)
+            img_bytes = buf.getvalue()
+        except Exception:
+            pass
         generated_bytes = await generate_gradio_img2img(img_bytes, prompt)
         if not generated_bytes:
             await msg.edit_text("Nvidia недоступна, генерирую через Flux...")


### PR DESCRIPTION
### Motivation
- Telegram stickers are commonly delivered as WebP and must be accepted as input for image commands while avoiding animated/video sticker blobs. 
- The Nvidia/Gradio img2img flow is more reliable with standard JPEG/RGB inputs, so WebP sticker inputs need normalization.

### Description
- Added static sticker handling to `get_image_attachment_from_message` for both direct messages and replies while filtering out `is_animated` and `is_video` stickers. 
- Added input normalization in `handle_nvidia_command`: after `download_telegram_image(bot, photo)` the bytes are opened with PIL, converted to `RGB` and saved to a JPEG buffer (`quality=95`), with a safe `except` fallback to keep the original bytes. 
- Changes applied to `AI/picgeneration.py` and committed.

### Testing
- Ran `python -m py_compile AI/picgeneration.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbb58d69748324b7a02478aa99b6bd)