### PR TITLE
Add mugshot generation handler and router for "магшот"

### DIFF
--- a/AI/picgeneration.py
+++ b/AI/picgeneration.py
@@ -559,6 +559,47 @@ async def handle_redraw_command(message: types.Message):
         await msg.edit_text("Ошибка анализа или генерации.")
 
 
+async def handle_mugshot_command(message: types.Message):
+    photo, _ = await extract_image_and_prompt(message, "магшот")
+    if not photo:
+        return await message.reply("Нужна картинка. Реплайни на фото или отправь фото с подписью «магшот».")
+
+    chat_id = str(message.chat.id)
+    active_model = get_active_model(chat_id)
+    msg = await message.reply("📸 Делаю магшот...")
+
+    try:
+        img_bytes = await download_telegram_image(bot, photo)
+
+        analysis_prompt = (
+            "Identify the main character/person/creature in this image. "
+            "Return ONLY a short description (5-12 words). "
+            "If there are multiple characters, pick the most prominent one. "
+            "No background details."
+        )
+
+        subject = await analyze_image_for_redraw(img_bytes, analysis_prompt, active_model, chat_id)
+        subject = (subject or "").strip()
+        if not subject or len(subject) > 180:
+            subject = "a person"
+
+        final_prompt = (
+            f"police mugshot photo of {subject}, "
+            "front view, centered, "
+            "height measurement chart background, "
+            "holding arrest placard with random ID number, "
+            "neutral expression, "
+            "harsh flash lighting, "
+            "realistic photography, sharp focus, high detail, 8k"
+        )
+
+        await robust_image_generation(message, final_prompt, msg, skip_translate=True)
+
+    except Exception as e:
+        logging.error(f"Mugshot error: {e}")
+        await msg.edit_text("Ошибка анализа или генерации.")
+
+
 async def handle_nvidia_command(message: types.Message):
     photo, prompt = await extract_image_and_prompt(message, "нвидиа")
     if not photo:

--- a/main.py
+++ b/main.py
@@ -139,6 +139,7 @@ from AI.picgeneration import (
     handle_pun_image_command,
     handle_image_generation_command,
     handle_redraw_command,
+    handle_mugshot_command,
     handle_edit_command,
     handle_kandinsky_generation_command,
     handle_nvidia_command
@@ -777,6 +778,30 @@ async def generate_image_kandinsky(message: types.Message):
 )
 async def redraw_image(message: types.Message):
     await handle_redraw_command(message)
+
+@router.message(
+    lambda message: (
+        (
+            (message.photo and message.caption and "магшот" in message.caption.lower()) or
+            (message.document and message.caption and "магшот" in message.caption.lower()) or
+            (message.sticker and message.caption and "магшот" in message.caption.lower()) or
+            (
+                message.text and "магшот" in message.text.lower() and message.reply_to_message and
+                (
+                    message.reply_to_message.photo or
+                    (message.reply_to_message.document and message.reply_to_message.document.mime_type and message.reply_to_message.document.mime_type.startswith("image/")) or
+                    (
+                        message.reply_to_message.sticker and
+                        not message.reply_to_message.sticker.is_animated and
+                        not message.reply_to_message.sticker.is_video
+                    )
+                )
+            )
+        ) and message.from_user.id not in BLOCKED_USERS
+    )
+)
+async def mugshot_image(message: types.Message):
+    await handle_mugshot_command(message)
 
 @router.message(
     lambda message: (


### PR DESCRIPTION
### Motivation
- Add a new image-generation feature "магшот" that produces police-style mugshot images from an attached or replied image.
- Reuse existing download/vision/generation helpers to provide consistent UX and avoid duplicating logic.

### Description
- Added `handle_mugshot_command` in `AI/picgeneration.py` which finds the image via `extract_image_and_prompt(message, "магшот")`, downloads it with `download_telegram_image`, and sends an intermediate message `📸 Делаю магшот...`.
- Uses `analyze_image_for_redraw` with a short vision prompt (`Identify the main character... Return ONLY a short description (5-12 words).`) to get `subject` and falls back to `"a person"` if analysis is empty or invalid.
- Builds an English mugshot prompt (front view, height chart background, arrest placard, neutral expression, harsh flash, realistic photography) and calls `robust_image_generation(..., skip_translate=True)` to generate and send the image.
- Wired the handler in `main.py` by importing `handle_mugshot_command` and adding a `@router.message` rule that triggers on the substring `"магшот"` in `text` or `caption` and supports photo, `document` with `image/*`, and static stickers (reply flow).

### Testing
- Compiled sources successfully with `python -m py_compile AI/picgeneration.py main.py` (no syntax errors).
- Changes were committed as part of the update (`Add mugshot image generation command support`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db83e0e1108324a2e11276e2cf183c)