### PR TITLE
Use nickname instead of username in mugshot placard

### DIFF
--- a/AI/picgeneration.py
+++ b/AI/picgeneration.py
@@ -584,16 +584,19 @@ async def handle_mugshot_command(message: types.Message):
         if not subject or len(subject) > 180:
             subject = "a person"
 
-        username = (
-            f"@{message.from_user.username}"
-            if message.from_user and message.from_user.username
-            else (message.from_user.full_name if message.from_user else "Unknown user")
-        )
+        if message.from_user:
+            first_name = message.from_user.first_name or ""
+            last_name = message.from_user.last_name or ""
+            nickname = f"{first_name} {last_name}".strip() if last_name else first_name
+            if not nickname.strip():
+                nickname = message.from_user.full_name or "Unknown user"
+        else:
+            nickname = "Unknown user"
         date_str = datetime.now().strftime("%Y-%m-%d")
         chat_name = message.chat.title if message.chat and message.chat.title else "PRIVATE"
         if len(chat_name) > 30:
             chat_name = chat_name[:30]
-        placard_text = f"{username} | {date_str} | CHAT: {chat_name}"
+        placard_text = f"{nickname} | {date_str} | CHAT: {chat_name}"
 
         final_prompt = (
             f"police mugshot photo of {subject}, "


### PR DESCRIPTION
### Motivation
- Ensure the mugshot arrest placard displays the user's nickname (first name and optional last name) instead of the Telegram `username`, while keeping date and chat behavior unchanged.

### Description
- Replace `message.from_user.username` usage with `nickname` built from `message.from_user.first_name` and optional `message.from_user.last_name`, with a fallback to `full_name` or `Unknown user` if empty.
- Update the placard text to use the new format `"{nickname} | {date_str} | CHAT: {chat_name}"` and keep date as `YYYY-MM-DD` and chat as `message.chat.title` or `PRIVATE` with truncation to 30 characters.

### Testing
- Ran `python -m py_compile AI/picgeneration.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db878df89c832483e8e42f80c400ec)