### PR TITLE
Add Gemini-first image generation with model queue fallback

### DIFF
--- a/AI/picgeneration.py
+++ b/AI/picgeneration.py
@@ -312,18 +312,47 @@ async def cf_generate_t2i(prompt: str) -> Optional[bytes]:
 # ГЛАВНЫЙ ОРКЕСТРАТОР (WATERFALL)
 # =============================================================================
 
-async def robust_image_generation(message: types.Message, prompt_ru: str, processing_msg: types.Message, skip_translate: bool = False):
+async def robust_image_generation_bytes(
+    message: types.Message,
+    prompt_ru: str,
+    processing_msg: types.Message,
+    skip_translate: bool = False,
+) -> Optional[bytes]:
     global PIPELINE_ID
     
     # Переводим и обогащаем промпт один раз для всей цепочки
     await processing_msg.edit_text("Использую ебучий Flux...")
     prompt_en = prompt_ru if skip_translate else await translate_to_en(prompt_ru)
+    active_model = get_active_model(str(message.chat.id))
+
+    # 0. Gemini image queue (только если пользователь выбрал gemini)
+    if active_model == "gemini":
+        try:
+            gemini_prompt = prompt_en or prompt_ru
+            gemini_img, gemini_meta = await asyncio.to_thread(
+                lambda: model.generate_image(gemini_prompt, chat_id=message.chat.id)
+            )
+            if gemini_img:
+                logging.info(
+                    "Picgeneration Gemini image generated successfully: model=%s key_idx=%s",
+                    gemini_meta.get("model"),
+                    gemini_meta.get("key_idx"),
+                )
+                return gemini_img
+
+            logging.warning(
+                "Picgeneration Gemini image unavailable: model=%s key_idx=%s error=%s",
+                gemini_meta.get("model"),
+                gemini_meta.get("key_idx"),
+                gemini_meta.get("error"),
+            )
+        except Exception as e:
+            logging.warning(f"Picgeneration Gemini image stage failed, fallback to Pollinations: {e}")
 
     # 1. Flux (Pollinations)
     img = await pollinations_generate(prompt_en)
     if img:
-        await processing_msg.delete()
-        return await send_generated_photo(message, img, "flux.png")
+        return img
 
     # 2. Kandinsky
     await processing_msg.edit_text("Использую ебучий Kandinsky...")
@@ -333,19 +362,26 @@ async def robust_image_generation(message: types.Message, prompt_ru: str, proces
         if uuid:
             img, _ = await asyncio.to_thread(kandinsky_api.check, uuid)
             if img:
-                await processing_msg.delete()
-                return await send_generated_photo(message, img, "kandinsky.png")
+                return img
 
     # 3. Резервы
     await processing_msg.edit_text("Использую резервный анал...")
     img = await hf_generate(prompt_en, 'black-forest-labs/FLUX.1-schnell')
     if not img: img = await cf_generate_t2i(prompt_en)
-    
+    return img
+
+
+async def robust_image_generation(message: types.Message, prompt_ru: str, processing_msg: types.Message, skip_translate: bool = False):
+    img = await robust_image_generation_bytes(
+        message=message,
+        prompt_ru=prompt_ru,
+        processing_msg=processing_msg,
+        skip_translate=skip_translate,
+    )
     if img:
         await processing_msg.delete()
-        await send_generated_photo(message, img, "ai_image.png")
-    else:
-        await processing_msg.edit_text("Иди нахуй, я спать")
+        return await send_generated_photo(message, img, "ai_image.png")
+    await processing_msg.edit_text("Иди нахуй, я спать")
 
 # =============================================================================
 # АНАЛИЗ ИЗОБРАЖЕНИЯ ЧЕРЕЗ ДОСТУПНЫЕ МОДЕЛИ
@@ -447,16 +483,17 @@ async def handle_pun_image_command(message: types.Message):
         final_word = parts[1].strip()
         
         await msg.edit_text("Ща скаламбурю нахуй")
-        
-        prompt_en = await translate_to_en(f"A creative surreal hybrid of {source_raw}, visual pun, digital art, high resolution")
-        
-        img_data = await pollinations_generate(prompt_en)
-        if not img_data:
-            global PIPELINE_ID
-            if not PIPELINE_ID: PIPELINE_ID = await asyncio.to_thread(kandinsky_api.get_pipeline)
-            if PIPELINE_ID:
-                uuid, _ = await asyncio.to_thread(kandinsky_api.generate, f"Гибрид {source_raw}, каламбур", PIPELINE_ID)
-                if uuid: img_data, _ = await asyncio.to_thread(kandinsky_api.check, uuid)
+
+        pun_image_prompt = (
+            f"Гибрид {source_raw}, визуальный каламбур, абсурд, "
+            "высокая детализация, яркая композиция, digital art"
+        )
+        img_data = await robust_image_generation_bytes(
+            message=message,
+            prompt_ru=pun_image_prompt,
+            processing_msg=msg,
+            skip_translate=False,
+        )
         
         if img_data:
             path = await asyncio.to_thread(_overlay_text_on_image, img_data, final_word)

--- a/AI/wrapper.py
+++ b/AI/wrapper.py
@@ -4,7 +4,7 @@ import os
 import time
 import logging
 import threading
-from typing import Optional, List, Any, Callable, Tuple
+from typing import Optional, List, Any, Callable, Tuple, Dict
 from groq import Groq
 from PIL import Image
 import base64
@@ -117,6 +117,103 @@ class ModelFallbackWrapper:
             chat_id=kwargs.pop("chat_id", None),
             request_fn=lambda model_obj: model_obj.generate_content(*args, **kwargs)
         )
+
+    def _extract_image_bytes(self, response: Any) -> Optional[bytes]:
+        candidates = getattr(response, "candidates", None) or []
+        for candidate in candidates:
+            content = getattr(candidate, "content", None)
+            parts = getattr(content, "parts", None) or []
+            for part in parts:
+                inline_data = getattr(part, "inline_data", None)
+                if not inline_data:
+                    continue
+
+                mime_type = (getattr(inline_data, "mime_type", "") or "").lower()
+                if not mime_type.startswith("image/"):
+                    continue
+
+                data = getattr(inline_data, "data", None)
+                if not data:
+                    continue
+
+                if isinstance(data, bytes):
+                    return data
+
+                if isinstance(data, str):
+                    try:
+                        return base64.b64decode(data)
+                    except Exception:
+                        continue
+
+        return None
+
+    def generate_image(self, prompt: str, chat_id: int | None = None) -> tuple[bytes | None, Dict[str, Any]]:
+        from config import GEMINI_IMAGE_MODEL_QUEUE
+
+        model_queue = [self._normalize_model_name(name) for name in GEMINI_IMAGE_MODEL_QUEUE]
+        key_indices = self._iter_key_indices()
+
+        metadata: Dict[str, Any] = {
+            "model": None,
+            "key_idx": None,
+            "attempts": 0,
+            "error": None,
+        }
+
+        if not key_indices:
+            metadata["error"] = "Gemini API keys pool is empty"
+            return None, metadata
+
+        last_error: Optional[str] = None
+
+        for key_idx in key_indices:
+            api_key = self.keys_pool[key_idx]
+            for model_name in model_queue:
+                metadata["attempts"] += 1
+                metadata["model"] = model_name
+                metadata["key_idx"] = key_idx
+
+                logging.info("Gemini IMG try key_idx=%s model=%s", key_idx, model_name)
+
+                try:
+                    _global_throttle()
+                    model_obj = self._build_model(api_key, model_name)
+                    response = model_obj.generate_content(prompt)
+                    image_bytes = self._extract_image_bytes(response)
+
+                    if image_bytes:
+                        logging.info(
+                            "Gemini IMG success key_idx=%s model=%s size=%s",
+                            key_idx,
+                            model_name,
+                            len(image_bytes),
+                        )
+                        return image_bytes, metadata
+
+                    last_error = "response format is not image"
+                    logging.warning(
+                        "Gemini IMG fail key_idx=%s model=%s error=%s",
+                        key_idx,
+                        model_name,
+                        last_error,
+                    )
+                except Exception as error:
+                    status_code, error_type = _extract_error_details(error)
+                    last_error = str(error)
+                    logging.warning(
+                        "Gemini IMG fail key_idx=%s model=%s error=%s",
+                        key_idx,
+                        model_name,
+                        error,
+                    )
+
+                    if status_code == 429 or "429" in str(error) or error_type in ("ResourceExhausted", "QuotaExceeded"):
+                        continue
+
+                    continue
+
+        metadata["error"] = last_error or "All Gemini image models failed"
+        return None, metadata
 
     def start_chat(self, history=None, chat_id=None, user_id=None):
         queue = self._get_queue(chat_id)

--- a/config.py
+++ b/config.py
@@ -133,6 +133,13 @@ TTS_MODELS_QUEUE = [
     "gemini-2.5-flash-preview-tts"
 ]
 
+GEMINI_IMAGE_MODEL_QUEUE = [
+    "models/gemini-2.5-flash-image",
+    "models/gemini-3.1-flash-image-preview",
+    "models/gemini-3-pro-image-preview",
+    "models/nano-banana-pro-preview",
+]
+
 # --- GIGACHAT MODEL QUEUES ---
 GIGACHAT_MODEL_QUEUE_DEFAULT = ["GigaChat-2"]
 GIGACHAT_MODEL_QUEUE_SPECIAL = ["GigaChat-2-Max"]


### PR DESCRIPTION
### Motivation
- Make image generation use Gemini when the chat `active_model` is set to `gemini` and ensure Gemini image attempts are tried through a dedicated model queue with key/model fallback and logging.
- Preserve existing Pollinations → Kandinsky → HF/CF waterfall as a safe fallback when Gemini is unavailable or returns non-image content.

### Description
- Added `GEMINI_IMAGE_MODEL_QUEUE` in `config.py` with the requested model names and order to drive Gemini image attempts via `config.GEMINI_IMAGE_MODEL_QUEUE`.
- Extended `ModelFallbackWrapper` in `AI/wrapper.py` with `_extract_image_bytes(response)` to pull image data from `response.candidates[*].content.parts[*].inline_data` and added `generate_image(prompt, chat_id)` which iterates key indices and models from the image queue, returns `(bytes | None, metadata)` and logs `Gemini IMG try/success/fail ...` messages.
- Integrated Gemini into image orchestration in `AI/picgeneration.py` by introducing `robust_image_generation_bytes()` and making `robust_image_generation()` call it, so image commands first try Gemini when `get_active_model(...) == "gemini"` and then fall back to Pollinations → Kandinsky → HF/CF without breaking prior behavior.
- Updated the pun command (`скаламбурь`) to use the shared robust image pipeline so it also benefits from Gemini-first attempts and unified logging.

### Testing
- Ran `python -m py_compile config.py AI/wrapper.py AI/picgeneration.py` and compilation succeeded without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea244bc18c83248f01e32d5901820f)