### PR TITLE
Use Gemini wrapper for redraw image analysis (avoid direct genai usage)

### DIFF
--- a/AI/picgeneration.py
+++ b/AI/picgeneration.py
@@ -354,7 +354,7 @@ async def robust_image_generation(message: types.Message, prompt_ru: str, proces
 async def analyze_image_for_redraw(img_bytes: bytes, prompt: str, active_model: str, chat_id: str) -> str:
     """
     Анализирует изображение через выбранную модель.
-    Если основная недоступна — автоматически падает на Gemini Flash.
+    Если основная недоступна — автоматически падает на Gemini wrapper model.
     """
     if active_model == "groq":
         try:
@@ -365,7 +365,7 @@ async def analyze_image_for_redraw(img_bytes: bytes, prompt: str, active_model: 
             )
             return result
         except Exception as e:
-            logging.warning(f"Groq vision недоступен: {e}, падаем на Gemini Flash")
+            logging.warning(f"Groq vision недоступен: {e}, падаем на Gemini wrapper model")
 
     if active_model == "gigachat":
         try:
@@ -376,15 +376,19 @@ async def analyze_image_for_redraw(img_bytes: bytes, prompt: str, active_model: 
             ))
             return response.text.strip()
         except Exception as e:
-            logging.warning(f"GigaChat vision недоступен: {e}, падаем на Gemini Flash")
+            logging.warning(f"GigaChat vision недоступен: {e}, падаем на Gemini wrapper model")
 
-    # Gemini Flash — лёгкая модель, не тратим квоту gemini-2.5-pro
-    import google.generativeai as genai
-    logging.info("Анализируем изображение через Gemini Flash")
-    flash_model = genai.GenerativeModel("gemini-2.0-flash")
-    response = await asyncio.to_thread(lambda: flash_model.generate_content(
-        [prompt, {"mime_type": "image/jpeg", "data": img_bytes}]
+    logging.info("Анализируем изображение через Gemini wrapper model (fallback queue)")
+    response = await asyncio.to_thread(lambda: model.generate_content(
+        [prompt, {"mime_type": "image/jpeg", "data": img_bytes}],
+        chat_id=int(chat_id)
     ))
+
+    used_model = getattr(model, "last_used_model_name", None)
+    used_key_idx = getattr(model, "last_used_key_idx", None)
+    if used_model is not None or used_key_idx is not None:
+        logging.info(f"Gemini vision success model={used_model} key_idx={used_key_idx}")
+
     return response.text.strip()
 
 # =============================================================================


### PR DESCRIPTION
### Motivation
- Команда `перерисуй` падала с 429 из‑за прямого вызова `google.generativeai` и фиксированной модели `gemini-2.0-flash`, что обходило логику ротации ключей и fallback в wrapper-е из `config.py`.
- Нужно, чтобы все вызовы Gemini в `AI/picgeneration.py` шли через общий `model`-wrapper, чтобы включить очередь моделей, ротацию ключей и механизм fallback.

### Description
- В `AI/picgeneration.py` обновлён `analyze_image_for_redraw()` так, что вместо `google.generativeai`/`GenerativeModel("gemini-2.0-flash")` используется `model.generate_content(...)` из `config` и вызов обёрнут в `asyncio.to_thread` с передачей `chat_id`.
- Сохранён приоритет: сначала `groq`, затем `gigachat`, при ошибке происходит падение на Gemini через wrapper, и соответствующие warning‑логи обновлены.
- Добавлено логирование перед вызовом: `logging.info("Анализируем изображение через Gemini wrapper model (fallback queue)")` и логирование метаданных успешного вызова `model.last_used_model_name`/`model.last_used_key_idx`, если они доступны.
- Удалено использование прямых ссылок на `genai.GenerativeModel` и явной строки `"gemini-2.0-flash"` в пути анализа изображения; изменения локальны и касаются только `AI/picgeneration.py`.

### Testing
- Выполнена проверка синтаксиса: `python -m py_compile AI/picgeneration.py` — успешно.
- Проверено отсутствие оставшихся прямых ссылок на Gemini SDK/flash методом `rg -n "gemini-2.0-flash|genai\.GenerativeModel|google\.generativeai" AI/picgeneration.py` — ничего не найдено.
- Локальные сценарии вызова `analyze_image_for_redraw()` сохраняют приоритеты моделей и теперь используют wrapper для Gemini; автоматические тесты компиляции и поиска прошли успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecb390c0fc8324a8548baaa9a35a0c)