### PR TITLE
Deduplicate consecutive чоговорят log messages

### DIFF
--- a/sms_settings.py
+++ b/sms_settings.py
@@ -156,10 +156,13 @@ async def process_what_they_say(message: types.Message, chat_list: list, bot: Bo
                 if not text:
                     continue
 
-                recent_messages.append(
+                formatted_message = (
                     f"{_format_log_time(parsed['timestamp'])} "
                     f"{_format_log_author(parsed['username'], parsed['full_name'])}: {text}"
                 )
+                if recent_messages and recent_messages[-1] == formatted_message:
+                    continue
+                recent_messages.append(formatted_message)
     except Exception as e:
         logging.error(f"Ошибка при чтении последних сообщений чата {target_chat_id}: {e}")
         await message.reply("Не удалось прочитать сообщения. Возможно, я хуисос")


### PR DESCRIPTION
### Motivation
- The `чоговорят` output sometimes showed identical lines repeated due to duplicate log entries being preserved during reading. 
- Add a temporary read-time safeguard to avoid showing immediate full-text duplicates while the root cause of duplicate logging is investigated.

### Description
- In `process_what_they_say()` (file `sms_settings.py`) each output line is built into a `formatted_message` variable before appending. 
- If `recent_messages` is non-empty and its last item equals `formatted_message`, the record is skipped with `continue`. 
- Otherwise the code appends `formatted_message` to the `recent_messages` deque, preserving non-consecutive repeats.

### Testing
- Ran `python -m py_compile sms_settings.py` and the module compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a186a59e1148324812c878113a33450)