### PR TITLE
Запретить чоговорят для чатов с отключенными СМС/ММС

### DIFF
--- a/sms_settings.py
+++ b/sms_settings.py
@@ -119,6 +119,10 @@ async def process_what_they_say(message: types.Message, chat_list: list, bot: Bo
     command_text = message.text or ""
     parts = command_text.split(maxsplit=1)
 
+    if str(message.chat.id) in sms_disabled_chats:
+        await message.reply("СМС/ММС отключены в этом чате, чоговорят тоже нельзя.")
+        return
+
     if len(parts) < 2:
         await message.reply("Укажи номер чата: чоговорят <номер чата>")
         return
@@ -136,6 +140,11 @@ async def process_what_they_say(message: types.Message, chat_list: list, bot: Bo
 
     target_chat = filtered_chats[chat_index]
     target_chat_id = str(target_chat["id"])
+
+    if target_chat_id in sms_disabled_chats:
+        await message.reply("В этом чате СМС/ММС отключены, подсматривать туда тоже нельзя.")
+        return
+
     recent_messages = deque(maxlen=10)
 
     if not os.path.exists(LOG_FILE):


### PR DESCRIPTION
### Motivation
- Нужно запретить использование команды `чоговорят` когда в чате источнике отключены СМС/ММС и также запретить подсматривание в целевые чаты, где СМС/ММС отключены.

### Description
- Добавлена проверка в `process_what_they_say` в `sms_settings.py`, которая блокирует команду если исходный чат находится в `sms_disabled_chats` и отвечает пользователю о запрете.
- Добавлена проверка после выбора целевого чата в `process_what_they_say`, которая предотвращает чтение логов и подсматривание, если целевой чат в `sms_disabled_chats`.

### Testing
- Выполнена компиляция кода с помощью `python3 -m compileall sms_settings.py main.py`, которая прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a186c366a14832487c8fea8082197f6)