### PR TITLE
Remove generated video captions

### DIFF
--- a/AI/videogeneration.py
+++ b/AI/videogeneration.py
@@ -244,7 +244,6 @@ async def process_video_generation(message: types.Message, bot) -> None:
             return
         await message.reply_video(
             types.BufferedInputFile(video, filename="upupa_video.mp4"),
-            caption=f"🎬 {model}",
         )
         await status.delete()
     except Exception as e:
@@ -290,7 +289,6 @@ async def process_animate_photo(message: types.Message, bot) -> None:
             return
         await message.reply_video(
             types.BufferedInputFile(video, filename="upupa_alive.mp4"),
-            caption=f"🧟 {model}",
         )
         await status.delete()
     except Exception as e:


### PR DESCRIPTION
### Motivation
- Убрать автоматическую подпись модели (эмодзи + имя модели) у отправляемых сгенерированных видео, чтобы ролики приходили без подписи.

### Description
- Удалены аргументы `caption=f"🎬 {model}"` и `caption=f"🧟 {model}"` из вызовов `message.reply_video` в `AI/videogeneration.py`, оставив только отправку файла (`upupa_video.mp4` / `upupa_alive.mp4`).

### Testing
- Запущено `PYTHONPATH=. pytest tests/test_videogeneration.py`, все 5 тестов прошли с одним предупреждением, а запуск `pytest tests/test_videogeneration.py` без `PYTHONPATH` выдавал `ModuleNotFoundError` из-за окружения.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e3b927ccc832483e10db44b5b40a8)